### PR TITLE
fix ui not showing issue on mac os big sur

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six==1.13.0
 wheel
-PyQt5==5.14.1
+PyQt5==5.15.2
 pyqtgraph==0.10.0
 qdarkstyle
 requests

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def get_install_requires():
     install_requires = [
         "six==1.13.0",
         "wheel",
-        "PyQt5==5.14.1",
+        "PyQt5==5.15.2",
         "pyqtgraph==0.10.0",
         "qdarkstyle",
         "requests",


### PR DESCRIPTION

<img width="1051" alt="Screen Shot 2021-01-09 at 23 00 19" src="https://user-images.githubusercontent.com/3755789/104094861-83a06680-52ce-11eb-8ba5-c77f580e561f.png">

It seems that PyQt5 with version 5.14.1 is not compatible with macOS Big Sur (11.1).
The howtrader app will experience an ANR with a warning message 
> Warning: QApplication was created before pyqtgraph was imported; there may be problems (to avoid bugs, call QApplication.setGraphicsSystem("raster") before the QApplication is created).

Problem solved after upgrading to 5.15.2